### PR TITLE
The most significant changes include the addition of a new property `…

### DIFF
--- a/src/DistributedTasksOnTime.Orchestrator/TasksOrchestrator.cs
+++ b/src/DistributedTasksOnTime.Orchestrator/TasksOrchestrator.cs
@@ -100,6 +100,7 @@ internal class TasksOrchestrator : ITasksOrchestrator
             Logger.LogTrace("Task {0} terminated", runningTask.TaskName);
             runningTask.HostKey = distributedTaskInfo.HostKey;
             runningTask.TerminatedDate = distributedTaskInfo.EventDate;
+            scheduledTask.LastDurationInSeconds = (distributedTaskInfo.EventDate - runningTask.CreationDate).Seconds;
         }
         else if (distributedTaskInfo.State == DistributedTasksOnTime.TaskState.Canceling)
         {
@@ -400,7 +401,8 @@ internal class TasksOrchestrator : ITasksOrchestrator
                 if (checkTaskIsRunning.Timeout < DateTime.Now)
                 {
                     await TerminateTask(runningTask.TaskName);
-                }
+					_checkTaskIsRunningList.Remove(runningTask.Id, out var checkTaskIsRunningToRemove);
+				}
                 continue;
             }
 

--- a/src/DistributedTasksOnTime.Shared/ScheduledTask.cs
+++ b/src/DistributedTasksOnTime.Shared/ScheduledTask.cs
@@ -1,4 +1,6 @@
-﻿namespace DistributedTasksOnTime;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace DistributedTasksOnTime;
 
 public class ScheduledTask
 {
@@ -18,5 +20,7 @@ public class ScheduledTask
 	public string Description { get; set; }
 	public ProcessMode ProcessMode { get; set; }
 	public bool FromEditor { get; set; } = false;
+	[NotMapped]
+    public int LastDurationInSeconds { get; set; }
 }
 

--- a/src/TasksOnTimeCore/StartupExtensions.cs
+++ b/src/TasksOnTimeCore/StartupExtensions.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("TasksOnTimeCore.Tests", AllInternalsVisible = true)]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("TasksOnTimeCore.Scheduling", AllInternalsVisible = true)]
@@ -23,11 +24,7 @@ namespace TasksOnTime
 			services.AddSingleton(defaultSettings);
 
 			services.AddSingleton<ITasksHost, TasksHost>();
-			services.AddSingleton(fac =>
-			{
-				var pr = fac.GetService(defaultSettings.ProgresReporterType);
-				return pr as IProgressReporter;
-			});
+			services.TryAddTransient<IProgressReporter, DefaultProgressReporter>();
 
 			return services;
 		}

--- a/src/TasksOnTimeCore/TasksOnTimeCore.csproj
+++ b/src/TasksOnTimeCore/TasksOnTimeCore.csproj
@@ -3,8 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TasksOnTime</RootNamespace>
-    <Version>1.3.23.4</Version>
+    <Version>1.3.24.4</Version>
 	  <PackageReleaseNotes>
+		  1.3.24.4 : Change Registration of IProgressReporter
 		  1.3.23.4 : Fix memory leak
 		  1.2.22.3 : Replace IServiceProvider by IServiceScopeFactory (lifetime)
 		  1.2.21.3 : Fix Failed event


### PR DESCRIPTION
…LastDurationInSeconds` in both `TasksOrchestrator` and `ScheduledTask` classes. This property calculates the duration of a task in seconds when the task state is `Terminated`. Another important change is the update in the `TasksOrchestrator` class to remove the `runningTask` from `_checkTaskIsRunningList` when the task timeout is less than the current time. The `StartupExtensions` class has been updated to replace the singleton registration of `IProgressReporter` with a transient registration using `DefaultProgressReporter`. Lastly, the version of `TasksOnTimeCore` has been updated in the project file.

List of changes:

1. Addition of `LastDurationInSeconds` property in `TasksOrchestrator` class for `scheduledTask` to calculate task duration in seconds when task state is `Terminated`.
2. Update in `TasksOrchestrator` class to remove `runningTask` from `_checkTaskIsRunningList` when task timeout is less than the current time.
3. Addition of `LastDurationInSeconds` property in `ScheduledTask` class which is not mapped to the database.
4. Update in `StartupExtensions` class to replace singleton registration of `IProgressReporter` with transient registration using `DefaultProgressReporter`.
5. Update of `TasksOnTimeCore` version from `1.3.23.4` to `1.3.24.4` in the project file and corresponding update in package release notes.